### PR TITLE
Remove rules_cc_dependencies() from rules_cc setup

### DIFF
--- a/setup/rules_cc.bzl
+++ b/setup/rules_cc.bzl
@@ -1,4 +1,2 @@
-load("@rules_cc//cc:repositories.bzl", "rules_cc_dependencies")
-
 def rules_cc_setup():
-    rules_cc_dependencies()
+    pass # placeholder


### PR DESCRIPTION
All required dependencies are already imported via rules_cc() and rules_cc_deps() in repositories.bzl.